### PR TITLE
Documentation

### DIFF
--- a/dayly-refresh-info/__init__.py
+++ b/dayly-refresh-info/__init__.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
-from functions.authentication import getAccessToken
-from functions.funcs import REFRESHDATASET
-from functions.funcs import sendTeamsAlert
+from .functions.authentication import getAccessToken
+from .functions.funcs import REFRESHDATASET
+from .functions.funcs import sendTeamsAlert
 import azure.functions as func
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient

--- a/dayly-refresh-info/__init__.py
+++ b/dayly-refresh-info/__init__.py
@@ -1,8 +1,8 @@
 import datetime
 import logging
-from .functions.authentication import getAccessToken
-from .functions.funcs import REFRESHDATASET
-from .functions.funcs import sendTeamsAlert
+from functions.authentication import getAccessToken
+from functions.funcs import REFRESHDATASET
+from functions.funcs import sendTeamsAlert
 import azure.functions as func
 from azure.identity import DefaultAzureCredential
 from azure.keyvault.secrets import SecretClient

--- a/dayly-refresh-info/function.json
+++ b/dayly-refresh-info/function.json
@@ -5,7 +5,7 @@
       "name": "mytimer",
       "type": "timerTrigger",
       "direction": "in",
-      "schedule": "0 0 7 * * 1-5"
+      "schedule": "0 0 6 * * 1-5"
     }
   ]
 }

--- a/dayly-refresh-info/functions/funcs.py
+++ b/dayly-refresh-info/functions/funcs.py
@@ -92,11 +92,12 @@ If error persists please contact system administrator!!''')
     def getRefreshInfo(self):
         '''Load latest refresh info on the dataset'''
         output = pd.DataFrame()
+
         for id, name in zip(self.datasetIds, self.datasetNames):
             uri = f"https://api.powerbi.com/v1.0/myorg/groups/{self.workspaceId}/datasets/{id}/refreshes"
             headers = {'Authorization': f'Bearer {self.accessToken}'}
             response = requests.get(uri, headers=headers)
-            if response.status_code == 200:
+            if response.status_code == 200: # Import dataset refresh types
                 response = json.loads(response.content)
                 res = pd.concat([pd.json_normalize(x) for x in response['value']])
                 res.sort_values(by='startTime', ascending=False, inplace=True)
@@ -104,10 +105,11 @@ If error persists please contact system administrator!!''')
                 res = res.iloc[0]
                 results = pd.DataFrame({'datasetname': [name], 'status': [
                                     res['status']], 'lastrefresh': [res['startTime']]})
-            elif response.status_code == 415:
+            elif response.status_code == 415: # Direct query dataset refresh types
                 results = pd.DataFrame({'datasetname': [name], 'status': [
                                     'Direct query, no refresh info'], 'lastrefresh': ['n.v.t.']})
-            else:
+            else: # Other types of dataset refreshes, e.g. no refresh
+                results = pd.DataFrame()
                 continue
             output = pd.concat([output, results], ignore_index=True)
             output.reset_index(drop=True,inplace=True)


### PR DESCRIPTION
Bugfix - refresh app no longer running with concat-related error:

`Result: Failure Exception: ValueError: No objects to concatenate Stack: File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 479, in _handle__invocation_request call_result = await self._loop.run_in_executor( File "/usr/local/lib/python3.10/concurrent/futures/thread.py", line 58, in run result = self.fn(*self.args, **self.kwargs) File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/dispatcher.py", line 752, in _run_sync_func return ExtensionManager.get_sync_invocation_wrapper(context, File "/azure-functions-host/workers/python/3.10/LINUX/X64/azure_functions_worker/extension.py", line 215, in _raw_invocation_wrapper result = function(**args) File "/home/site/wwwroot/dayly-refresh-info/__init__.py", line 48, in main results = apiconn.getRefreshInfo() File "/home/site/wwwroot/dayly-refresh-info/functions/funcs.py", line 101, in getRefreshInfo res = pd.concat([pd.json_normalize(x) for x in response['value']]) File "/home/site/wwwroot/.python_packages/lib/site-packages/pandas/core/reshape/concat.py", line 372, in concat op = _Concatenator( File "/home/site/wwwroot/.python_packages/lib/site-packages/pandas/core/reshape/concat.py", line 429, in __init__ raise ValueError("No objects to concatenate")`